### PR TITLE
feat: add LocalStack support

### DIFF
--- a/.docker/localstack/init-aws.sh
+++ b/.docker/localstack/init-aws.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo "--- Initializing S3 Buckets ---"
+
+# Set dummy AWS credentials for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+# Use AWS CLI with LocalStack endpoint
+aws --endpoint-url=http://localhost:4566 s3 mb s3://my-local-bucket
+aws --endpoint-url=http://localhost:4566 s3 mb s3://another-local-bucket
+
+echo "--- S3 Initialization Complete ---"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,33 @@ test:
 	go test -v ./...
 
 # ==================================================================================== #
+# DOCKER
+# ==================================================================================== #
+
+# Start compose services
+docker-up:
+	docker compose up -d
+	@echo "Waiting for server to be ready..."
+	@sleep 3
+
+# Stop compose services
+docker-down:
+	docker compose down
+
+# Clean compose volumes
+docker-clean:
+	docker compose down -v
+
+# Run init scrips
+docker-init:
+	@echo "==> Initializing Docker Services..."
+	./.docker/localstack/init-aws.sh
+	@echo "==> LocalStack successfully initialized"
+
+# Reset compose
+docker-reset: docker-clean docker-up docker-init
+
+# ==================================================================================== #
 # TESTING & MOCKING
 # ==================================================================================== #
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,14 +31,17 @@ func main() {
 	defer stop()
 
 	// Load AWS configuration
-	awsCfg, err := aws.LoadConfig(ctx, cfg.AWS.Region)
+	awsCfg, err := aws.LoadConfig(ctx, &cfg.AWS)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to load AWS configuration")
 	}
 
+	// Determine if we're using LocalStack
+	isLocal := cfg.AWS.EndpointURL != ""
+
 	// Create S3 client
-	s3Client := aws.NewS3Client(awsCfg)
-	s3Presigner := aws.NewS3Presigner(awsCfg)
+	s3Client := aws.NewS3Client(awsCfg, isLocal)
+	s3Presigner := aws.NewS3Presigner(awsCfg, isLocal)
 
 	// Initialize core service
 	core := core.NewCore(cfg, log, s3Client, s3Presigner)

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -3,6 +3,7 @@ server:
 
 aws:
   region: "us-east-1"
+  # endpoint_url: "http://localhost:4566" Only used for local development
 
 log:
   level: "info"  # debug, info, warn, error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,25 @@ x-environment: &shared-environment
   POSTGRES_PORT: ${POSTGRES_PORT:-5432}
 
 services:
+  localstack:
+    image: localstack/localstack:4
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=s3
+      - DEBUG=1
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./docker/localstack/init-aws.sh:/etc/localstack/init/ready.d/init-aws.sh
+    networks:
+      - explorer451
+    healthcheck:
+      test: ["CMD", "awslocal", "s3", "ls"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   postgres:
     image: postgres:16-alpine
     environment:

--- a/internal/aws/config.go
+++ b/internal/aws/config.go
@@ -3,25 +3,55 @@ package aws
 import (
 	"context"
 
+	appconfig "explorer451/internal/config"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 // LoadConfig loads AWS configuration using the default credential chain
-func LoadConfig(ctx context.Context, region string) (aws.Config, error) {
-	return config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
+// with support for custom endpoints (LocalStack)
+func LoadConfig(ctx context.Context, cfg *appconfig.AWSConfig) (aws.Config, error) {
+	var opts []func(*config.LoadOptions) error
+
+	opts = append(opts,
+		config.WithRegion(cfg.Region),
 		config.WithRetryMaxAttempts(3),
 	)
+
+	// If custom endpoint is provided, configure for LocalStack
+	if cfg.EndpointURL != "" {
+		// LocalStack uses static credentials
+		opts = append(opts,
+			config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "test")),
+			config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
+				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+					return aws.Endpoint{
+						URL:               cfg.EndpointURL,
+						HostnameImmutable: true,
+					}, nil
+				})),
+		)
+	}
+
+	return config.LoadDefaultConfig(ctx, opts...)
 }
 
 // NewS3Client creates a new S3 client
-func NewS3Client(cfg aws.Config) *s3.Client {
-	return s3.NewFromConfig(cfg)
+func NewS3Client(cfg aws.Config, usePathStyle bool) *s3.Client {
+	opts := []func(*s3.Options){
+		func(o *s3.Options) {
+			if usePathStyle {
+				o.UsePathStyle = true
+			}
+		},
+	}
+	return s3.NewFromConfig(cfg, opts...)
 }
 
 // NewS3Presigner creates a new S3 presigner client
-func NewS3Presigner(cfg aws.Config) *s3.PresignClient {
-	return s3.NewPresignClient(s3.NewFromConfig(cfg))
+func NewS3Presigner(cfg aws.Config, usePathStyle bool) *s3.PresignClient {
+	return s3.NewPresignClient(NewS3Client(cfg, usePathStyle))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,8 @@ type ServerConfig struct {
 
 // AWSConfig holds AWS specific configuration
 type AWSConfig struct {
-	Region string `koanf:"region"`
+	Region      string `koanf:"region"`
+	EndpointURL string `koanf:"endpoint_url"`
 }
 
 // LogConfig holds logging configuration


### PR DESCRIPTION
This pull request introduces support for LocalStack to enable local development and testing of AWS services. Key changes include updates to configuration, Docker setup, and AWS client initialization to support custom endpoints.

### LocalStack Integration:

* Added a `localstack` service to `docker-compose.yml` with S3 support
* Created a new script `.docker/localstack/init-aws.sh` to initialize S3 buckets in LocalStack during startup.
* Added `docker-init` and related commands to the `Makefile` for managing LocalStack services and initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using a local AWS S3 emulator (LocalStack), including configuration options for custom endpoints.
  - Introduced Docker Compose integration for LocalStack, enabling easy setup of a local S3 environment.
  - Provided a script to automatically initialize S3 buckets in the local development environment.

- **Chores**
  - Enhanced Makefile with new targets for managing Docker services and initializing the local environment.

- **Documentation**
  - Updated sample configuration to illustrate how to set a local AWS endpoint for development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->